### PR TITLE
Fix exec_result evaluation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,17 +16,17 @@ spider2/examples/airbnb002/seeds/RAW_REVIEWS.csv
 
 !spider2/resource/databases/local/local-map.jsonl
 
-methods/spider-agent-air/logs/*
-methods/spider-agent-air/output/*
-!methods/spider-agent-air/logs/README.md
-!methods/spider-agent-air/output/README.md
-
-
 methods/spider-agent/logs/*
 methods/spider-agent/output/*
+methods/spider-agent/examples/*
 !methods/spider-agent/logs/README.md
 !methods/spider-agent/output/README.md
 
+methods/spider-agent-snow/logs/*
+methods/spider-agent-snow/output/*
+methods/spider-agent-snow/examples/*
+!methods/spider-agent-snow/logs/README.md
+!methods/spider-agent-snow/output/README.md
 
 spider2-lite/evaluation_suite/*
 spider2-lite/fix_rows.py


### PR DESCRIPTION
This PR fixes two problems:
1. The score is calculated against incorrect number of examples. Whether there's an output for an example or not, the total number of examples should be the number of test examples (260) instead of `len(output_results)`.
2. This PR catches potential CSV parsing errors, which can cause the evaluation script to fail.

This PR also adds `examples` to `.gitignore`.