### PR TITLE
fix sf_bq291 semantic issue (Reference issue #117)

### DIFF
--- a/spider2-snow/evaluation_suite/gold/sql/sf_bq291.sql
+++ b/spider2-snow/evaluation_suite/gold/sql/sf_bq291.sql
@@ -65,7 +65,8 @@ WITH daily_forecasts AS (
         "NOAA_GLOBAL_FORECAST_SYSTEM"."NOAA_GLOBAL_FORECAST_SYSTEM"."NOAA_GFS0P25" AS "TRI"
     CROSS JOIN LATERAL FLATTEN(input => "TRI"."forecast") AS "forecast"
     WHERE
-        TO_TIMESTAMP_NTZ(TO_NUMBER("TRI"."creation_time") / 1000000) BETWEEN '2019-07-01' AND '2021-07-31'  
+        TO_TIMESTAMP_NTZ(TO_NUMBER("TRI"."creation_time")/1000000) >= '2019-07-01'
+          AND TO_TIMESTAMP_NTZ(TO_NUMBER("TRI"."creation_time")/1000000) <  '2019-08-01'  
         AND ST_DWITHIN(
             ST_GEOGFROMWKB("TRI"."geography"),
             ST_POINT(26.75, 51.5),


### PR DESCRIPTION
Issue #117 Fix date range filter in sf_bq291.sql query

The original query was incorrectly filtering weather data for a period spanning from July 2019 to July 2021 (over 2 years), when the question specifically asked for data from July 2019 only. 

Changes made:
- Modified the date filter conditions to strictly limit data to July 2019 (lines 68-69)
- Changed from:
  TO_TIMESTAMP_NTZ(TO_NUMBER("TRI"."creation_time")/1000000) BETWEEN '2019-07-01' AND '2021-07-31'
- To:
  TO_TIMESTAMP_NTZ(TO_NUMBER("TRI"."creation_time")/1000000) >= '2019-07-01'
  AND TO_TIMESTAMP_NTZ(TO_NUMBER("TRI"."creation_time")/1000000) < '2019-08-01'

This change ensures the query correctly returns daily weather summaries only for July 2019, as specified in the original question, while maintaining the spatial filter of 5km radius around the given coordinates (26.75, 51.5).

The following query has been verified with Snowflake to be working as intended, and the exec_result for sf_bq291 remains the same.